### PR TITLE
Suppress deprecation warnings

### DIFF
--- a/Sources/GRPC/FakeChannel.swift
+++ b/Sources/GRPC/FakeChannel.swift
@@ -19,7 +19,8 @@ import NIOEmbedded
 import SwiftProtobuf
 
 // This type is deprecated, but we need to '@unchecked Sendable' to avoid warnings in our own code.
-@available(swift, deprecated: 5.6)
+// The deprecation was suppressed to avoid excessive warnings while clients move away from it.
+// @available(swift, deprecated: 5.6)
 extension FakeChannel: @unchecked Sendable {}
 
 /// A fake channel for use with generated test clients.
@@ -31,12 +32,16 @@ extension FakeChannel: @unchecked Sendable {}
 ///
 /// Users will typically not be required to interact with the channel directly, instead they should
 /// do so via a generated test client.
-@available(
-  swift,
-  deprecated: 5.6,
-  message:
-    "GRPCChannel implementations must be Sendable but this implementation is not. Using a client and server on localhost is the recommended alternative."
-)
+///
+/// This type is deprecated, but the deprecation was suppressed to avoid excessive warnings while
+/// clients move away from it.
+///
+/// @available(
+///   swift,
+///   deprecated: 5.6,
+///   message:
+///     "GRPCChannel implementations must be Sendable but this implementation is not. Using a client and server on localhost is the recommended alternative."
+/// )
 public class FakeChannel: GRPCChannel {
   /// Fake response streams keyed by their path.
   private var responseStreams: [String: CircularBuffer<Any>]
@@ -157,7 +162,8 @@ public class FakeChannel: GRPCChannel {
   }
 }
 
-@available(swift, deprecated: 5.6)
+// The deprecation was suppressed to avoid excessive warnings while clients move away from it.
+// @available(swift, deprecated: 5.6)
 extension FakeChannel {
   /// Dequeue a proxy for the given path and casts it to the given type, if one exists.
   private func dequeueResponseStream<Stream>(

--- a/Sources/protoc-gen-grpc-swift/Generator-Client.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Client.swift
@@ -189,10 +189,12 @@ extension Generator {
   }
 
   private func printClassBackedServiceClientImplementation() {
-    self.println("@available(*, deprecated)")
+    // The deprecation was suppressed to avoid excessive warnings while clients move away from it.
+    // self.println("@available(*, deprecated)")
     self.println("extension \(clientClassName): @unchecked Sendable {}")
     self.println()
-    self.println("@available(*, deprecated, renamed: \"\(clientStructName)\")")
+    // The deprecation was suppressed to avoid excessive warnings while clients move away from it.
+    // self.println("@available(*, deprecated, renamed: \"\(clientStructName)\")")
     println("\(access) final class \(clientClassName): \(clientProtocolName) {")
     self.withIndentation {
       println("private let lock = Lock()")
@@ -532,14 +534,16 @@ extension Generator {
   }
 
   private func printTestClient() {
-    self.println("@available(swift, deprecated: 5.6)")
+    // The deprecation was suppressed to avoid excessive warnings while clients move away from it.
+    // self.println("@available(swift, deprecated: 5.6)")
     self.println("extension \(self.testClientClassName): @unchecked Sendable {}")
     self.println()
-    self.println(
-      "@available(swift, deprecated: 5.6, message: \"Test clients are not Sendable "
-        + "but the 'GRPCClient' API requires clients to be Sendable. Using a localhost client and "
-        + "server is the recommended alternative.\")"
-    )
+    // The deprecation was suppressed to avoid excessive warnings while clients move away from it.
+    // self.println(
+    //   "@available(swift, deprecated: 5.6, message: \"Test clients are not Sendable "
+    //     + "but the 'GRPCClient' API requires clients to be Sendable. Using a localhost client and "
+    //     + "server is the recommended alternative.\")"
+    // )
     self.println(
       "\(self.access) final class \(self.testClientClassName): \(self.clientProtocolName) {"
     )


### PR DESCRIPTION
Deprecation warnings on FakeChannel and on generated code, while valid, pollute the builds of clients that depend heavily on them. This suppression allows for these clients to transition out of the deprecated APIs without compromising their build output readability.