### PR TITLE
Soft-deprecate FakeChannel and TestsClient

### DIFF
--- a/Sources/GRPC/FakeChannel.swift
+++ b/Sources/GRPC/FakeChannel.swift
@@ -19,8 +19,8 @@ import NIOEmbedded
 import SwiftProtobuf
 
 // This type is deprecated, but we need to '@unchecked Sendable' to avoid warnings in our own code.
-// The deprecation was suppressed to avoid excessive warnings while clients move away from it.
-// @available(swift, deprecated: 5.6)
+// The original deprecation is from Swift 5.6, but we're suppressing it to avoid excessive warnings on clients.
+@available(swift, deprecated: 99999)
 extension FakeChannel: @unchecked Sendable {}
 
 /// A fake channel for use with generated test clients.
@@ -33,15 +33,13 @@ extension FakeChannel: @unchecked Sendable {}
 /// Users will typically not be required to interact with the channel directly, instead they should
 /// do so via a generated test client.
 ///
-/// This type is deprecated, but the deprecation was suppressed to avoid excessive warnings while
-/// clients move away from it.
-///
-/// @available(
-///   swift,
-///   deprecated: 5.6,
-///   message:
-///     "GRPCChannel implementations must be Sendable but this implementation is not. Using a client and server on localhost is the recommended alternative."
-/// )
+/// The original deprecation is from Swift 5.6, but we're suppressing it to avoid excessive warnings on clients.
+@available(
+  swift,
+  deprecated: 99999,
+  message:
+    "GRPCChannel implementations must be Sendable but this implementation is not. Using a client and server on localhost is the recommended alternative."
+)
 public class FakeChannel: GRPCChannel {
   /// Fake response streams keyed by their path.
   private var responseStreams: [String: CircularBuffer<Any>]
@@ -162,8 +160,8 @@ public class FakeChannel: GRPCChannel {
   }
 }
 
-// The deprecation was suppressed to avoid excessive warnings while clients move away from it.
-// @available(swift, deprecated: 5.6)
+// The original deprecation is from Swift 5.6, but we're suppressing it to avoid excessive warnings on clients.
+@available(swift, deprecated: 99999)
 extension FakeChannel {
   /// Dequeue a proxy for the given path and casts it to the given type, if one exists.
   private func dequeueResponseStream<Stream>(

--- a/Sources/protoc-gen-grpc-swift/Generator-Client.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Client.swift
@@ -190,11 +190,11 @@ extension Generator {
 
   private func printClassBackedServiceClientImplementation() {
     // The deprecation was suppressed to avoid excessive warnings while clients move away from it.
-    // self.println("@available(*, deprecated)")
+    self.println("@available(swift, deprecated: 99999)")
     self.println("extension \(clientClassName): @unchecked Sendable {}")
     self.println()
     // The deprecation was suppressed to avoid excessive warnings while clients move away from it.
-    // self.println("@available(*, deprecated, renamed: \"\(clientStructName)\")")
+    self.println("@available(swift, deprecated: 99999, renamed: \"\(clientStructName)\")")
     println("\(access) final class \(clientClassName): \(clientProtocolName) {")
     self.withIndentation {
       println("private let lock = Lock()")
@@ -535,15 +535,15 @@ extension Generator {
 
   private func printTestClient() {
     // The deprecation was suppressed to avoid excessive warnings while clients move away from it.
-    // self.println("@available(swift, deprecated: 5.6)")
+    self.println("@available(swift, deprecated: 99999)")
     self.println("extension \(self.testClientClassName): @unchecked Sendable {}")
     self.println()
     // The deprecation was suppressed to avoid excessive warnings while clients move away from it.
-    // self.println(
-    //   "@available(swift, deprecated: 5.6, message: \"Test clients are not Sendable "
-    //     + "but the 'GRPCClient' API requires clients to be Sendable. Using a localhost client and "
-    //     + "server is the recommended alternative.\")"
-    // )
+    self.println(
+      "@available(swift, deprecated: 99999, message: \"Test clients are not Sendable "
+        + "but the 'GRPCClient' API requires clients to be Sendable. Using a localhost client and "
+        + "server is the recommended alternative.\")"
+    )
     self.println(
       "\(self.access) final class \(self.testClientClassName): \(self.clientProtocolName) {"
     )


### PR DESCRIPTION
Instead of commenting-out the deprecation attributes of FakeChannel and the generated test client classes, it’s better to soft-deprecate them (i.e. set their deprecated version to a very high number).

That way developers know that the types will eventually get deprecated.